### PR TITLE
emulation: Breaking long timing paths

### DIFF
--- a/rtl/control.sv
+++ b/rtl/control.sv
@@ -33,6 +33,8 @@ module control
   output logic load_ir,
   output logic load_mdr,
   output logic load_reg,
+  output logic load_imm_reg,     // Load immediate register
+  output logic load_alu_reg,     // Load ALU output register
   output logic mdr_mux_sel,
   output rs1_mux_sel_t  rs1_mux_sel,
   output rs2_mux_sel_t  rs2_mux_sel,
@@ -93,37 +95,50 @@ module control
 
     // Branch Instructions
     BRANCH_0,                     // Evaluate branch condition (BEQ, BNE, BLT, BGE, BLTU, BGEU)
-    BRANCH_T,                     // Branch taken: PC <- PC + IMM
+    BRANCH_T,                     // Branch taken: compute PC+IMM, load alu_reg
+    BRANCH_T_WB,                  // Branch taken writeback: load PC from alu_reg
 
     // Common States
-    PC_INC,                       // PC <- PC + 4 (advance to next instruction)
+    PC_INC,                       // PC <- PC + 4 (compute in ALU, load alu_reg)
+    PC_INC_WB,                    // PC_INC writeback: load PC from alu_reg
 
     // Jump Instructions
-    JAL_0,                        // JAL: RD <- PC + 4 (save return address)
-    JAL_1,                        // JAL: PC <- PC + IMM (jump to target)
+    JAL_0,                        // JAL: RD <- PC + 4 (compute in ALU, load alu_reg)
+    JAL_0_WB,                     // JAL_0 writeback: load RD from alu_reg
+    JAL_1,                        // JAL: PC <- PC + IMM (compute in ALU, load alu_reg)
+    JAL_1_WB,                     // JAL_1 writeback: load PC from alu_reg
 
     // ALU Instructions
-    REG_REG,                      // R-type: RD <- RS1 op RS2 (register-register operations)
-    REG_IMM,                      // I-type: RD <- RS1 op IMM (register-immediate operations)
+    REG_REG,                      // R-type: compute RS1 op RS2, load alu_reg
+    REG_REG_WB,                   // R-type writeback: load RD from alu_reg
+    REG_IMM,                      // I-type: compute RS1 op IMM, load alu_reg
+    REG_IMM_WB,                   // I-type writeback: load RD from alu_reg
 
     // Upper Immediate Instructions
-    LUI_0,                        // LUI: RD <- IMM (load upper immediate)
-    AUIPC_0,                      // AUIPC: RD <- PC + IMM (add upper immediate to PC)
+    LUI_0,                        // LUI: compute IMM, load alu_reg
+    LUI_1,                        // LUI writeback: load RD from alu_reg
+    AUIPC_0,                      // AUIPC: compute PC+IMM, load alu_reg
+    AUIPC_1,                      // AUIPC writeback: load RD from alu_reg
 
     // Jump and Link Register
-    JALR_0,                       // JALR: RD <- PC + 4 (save return address)
-    JALR_1,                       // JALR: PC <- RS1 + IMM (jump to computed address)
+    JALR_0,                       // JALR: RD <- PC + 4 (compute in ALU, load alu_reg)
+    JALR_0_WB,                    // JALR_0 writeback: load RD from alu_reg
+    JALR_1,                       // JALR: PC <- RS1 + IMM (compute in ALU, load alu_reg)
+    JALR_1_WB,                    // JALR_1 writeback: load PC from alu_reg
 
     // Load Instructions (Memory Read)
-    LD_0,                         // MAR <- RS1 + IMM (compute memory address)
+    LD_0,                         // MAR <- RS1 + IMM (compute in ALU, load alu_reg)
+    LD_0_WB,                      // LD_0 writeback: load MAR from alu_reg
     LD_1,                         // Initiate memory read
     LD_2,                         // Wait for memory response
     LD_3,                         // MDR <- M[MAR] (capture loaded data)
     LD_4,                         // RD <- MDR (write to destination register)
 
     // Store Instructions (Memory Write)
-    ST_0,                         // MAR <- RS1 + IMM (compute memory address)
-    ST_1,                         // MDR <- RS2 (prepare data to store)
+    ST_0,                         // MAR <- RS1 + IMM (compute in ALU, load alu_reg)
+    ST_0_WB,                      // ST_0 writeback: load MAR from alu_reg
+    ST_1,                         // MDR <- RS2 (compute in ALU, load alu_reg)
+    ST_1_WB,                      // ST_1 writeback: load MDR from alu_reg
     ST_2,                         // Initiate memory write
     ST_3,                         // Wait for memory write completion
 
@@ -280,54 +295,87 @@ module control
           end
         endcase
       end
-      BRANCH_T : begin  // Branch taken: update PC and return to fetch
+      BRANCH_T : begin  // Branch taken: compute PC+IMM, load alu_reg
+        next_state = BRANCH_T_WB;
+      end
+      BRANCH_T_WB : begin  // Branch taken writeback: load PC from alu_reg
         next_state = FETCH_0;
       end
 
       // ==== COMMON STATES ====
-      PC_INC : begin  // Increment PC by 4, return to fetch
+      PC_INC : begin  // PC <- PC + 4 (compute in ALU, load alu_reg)
+        next_state = PC_INC_WB;
+      end
+      PC_INC_WB : begin  // PC_INC writeback: load PC from alu_reg
         next_state = FETCH_0;
       end
 
       // ==== JUMP AND LINK (JAL) ====
-      JAL_0 : begin  // Save return address (PC+4) to rd
+      JAL_0 : begin  // Save return address (PC+4) to rd (compute in ALU, load alu_reg)
+        next_state = JAL_0_WB;
+      end
+      JAL_0_WB : begin  // JAL_0 writeback: load RD from alu_reg
         next_state = JAL_1;
       end
-      JAL_1 : begin  // Update PC with target address, return to fetch
+      JAL_1 : begin  // Update PC with target address (compute in ALU, load alu_reg)
+        next_state = JAL_1_WB;
+      end
+      JAL_1_WB : begin  // JAL_1 writeback: load PC from alu_reg
         next_state = FETCH_0;
       end
 
       // ==== REGISTER-REGISTER ALU OPERATIONS ====
-      REG_REG : begin  // R-type: Compute result and write to rd, then increment PC
+      REG_REG : begin  // R-type: compute RS1 op RS2, load alu_reg
+        next_state = REG_REG_WB;
+      end
+      REG_REG_WB : begin  // R-type writeback: load RD from alu_reg
         next_state = PC_INC;
       end
 
       // ==== REGISTER-IMMEDIATE ALU OPERATIONS ====
-      REG_IMM : begin  // I-type: Compute result and write to rd, then increment PC
+      REG_IMM : begin  // I-type: compute RS1 op IMM, load alu_reg
+        next_state = REG_IMM_WB;
+      end
+      REG_IMM_WB : begin  // I-type writeback: load RD from alu_reg
         next_state = PC_INC;
       end
 
       // ==== LOAD UPPER IMMEDIATE ====
-      LUI_0 : begin  // Load immediate into rd, then increment PC
+      LUI_0 : begin  // Load immediate into rd (compute in ALU, load alu_reg)
+        next_state = LUI_1;
+      end
+      LUI_1 : begin  // LUI writeback: load RD from alu_reg
         next_state = PC_INC;
       end
 
       // ==== ADD UPPER IMMEDIATE TO PC ====
-      AUIPC_0 : begin  // Compute PC+imm and write to rd, then increment PC
+      AUIPC_0 : begin  // Compute PC+imm (in ALU, load alu_reg)
+        next_state = AUIPC_1;
+      end
+      AUIPC_1 : begin  // AUIPC writeback: load RD from alu_reg
         next_state = PC_INC;
       end
 
       // ==== JUMP AND LINK REGISTER (JALR) ====
-      JALR_0 : begin  // Save return address (PC+4) to rd
+      JALR_0 : begin  // Save return address (PC+4) to rd (compute in ALU, load alu_reg)
+        next_state = JALR_0_WB;
+      end
+      JALR_0_WB : begin  // JALR_0 writeback: load RD from alu_reg
         next_state = JALR_1;
       end
-      JALR_1 : begin  // Update PC with computed address (rs1+imm), return to fetch
+      JALR_1 : begin  // Update PC with computed address (compute in ALU, load alu_reg)
+        next_state = JALR_1_WB;
+      end
+      JALR_1_WB : begin  // JALR_1 writeback: load PC from alu_reg
         next_state = FETCH_0;
       end
 
       // ==== LOAD WORD ====
       // Multi-cycle memory read sequence
-      LD_0 : begin  // Compute effective address (rs1+imm)
+      LD_0 : begin  // Compute effective address (rs1+imm, load alu_reg)
+        next_state = LD_0_WB;
+      end
+      LD_0_WB : begin  // LD_0 writeback: load MAR from alu_reg
         next_state = LD_1;
       end
       LD_1 : begin  // Initiate memory read
@@ -348,10 +396,16 @@ module control
 
       // ==== STORE WORD ====
       // Multi-cycle memory write sequence
-      ST_0 : begin  // Compute effective address (rs1+imm)
+      ST_0 : begin  // Compute effective address (rs1+imm, load alu_reg)
+        next_state = ST_0_WB;
+      end
+      ST_0_WB : begin  // ST_0 writeback: load MAR from alu_reg
         next_state = ST_1;
       end
-      ST_1 : begin  // Prepare data from rs2 in MDR
+      ST_1 : begin  // Prepare data from rs2 in MDR (compute in ALU, load alu_reg)
+        next_state = ST_1_WB;
+      end
+      ST_1_WB : begin  // ST_1 writeback: load MDR from alu_reg
         next_state = ST_2;
       end
       ST_2 : begin  // Initiate memory write
@@ -433,6 +487,8 @@ module control
     load_pc = 1'b0;
     load_ir = 1'b0;
     load_reg = 1'b0;
+    load_imm_reg = 1'b0;
+    load_alu_reg = 1'b0;
     mdr_mux_sel = 0;
     databus_mux_sel = DATABUS_PC;
     rs1_mux_sel = RS1_OUT;
@@ -475,36 +531,48 @@ module control
         databus_mux_sel = DATABUS_MDR;
       end
       DECODE: begin
+        load_imm_reg = 1'b1;  // Capture immediate value for use in subsequent states
       end
       BRANCH_0 : begin
       end
       BRANCH_T : begin
-        load_pc = 1'b1;
-        databus_mux_sel = DATABUS_ALU;
+        load_alu_reg = 1'b1;
         rs1_mux_sel = RS1_PC;
         rs2_mux_sel = RS2_IMM;
+      end
+      BRANCH_T_WB : begin
+        load_pc = 1'b1;
+        databus_mux_sel = DATABUS_ALU;
       end
       PC_INC : begin
-        load_pc = 1'b1;
-        databus_mux_sel = DATABUS_ALU;
+        load_alu_reg = 1'b1;
         rs1_mux_sel = RS1_4;
         rs2_mux_sel = RS2_PC;
+      end
+      PC_INC_WB : begin
+        load_pc = 1'b1;
+        databus_mux_sel = DATABUS_ALU;
       end
       JAL_0 : begin
-        load_reg = 1'b1;
-        databus_mux_sel = DATABUS_ALU;
+        load_alu_reg = 1'b1;
         rs1_mux_sel = RS1_4;
         rs2_mux_sel = RS2_PC;
       end
-      JAL_1 : begin
-        load_pc = 1'b1;
+      JAL_0_WB : begin
+        load_reg = 1'b1;
         databus_mux_sel = DATABUS_ALU;
+      end
+      JAL_1 : begin
+        load_alu_reg = 1'b1;
         rs1_mux_sel = RS1_PC;
         rs2_mux_sel = RS2_IMM;
       end
-      REG_REG : begin
+      JAL_1_WB : begin
+        load_pc = 1'b1;
         databus_mux_sel = DATABUS_ALU;
-        load_reg = 1'b1;
+      end
+      REG_REG : begin
+        load_alu_reg = 1'b1;
         /*
         alu_op = {1'b0,funct3};
         if (funct3 == 3'b001 || funct3 == 3'b101 || funct3 == 3'b000) begin
@@ -549,10 +617,13 @@ module control
           3'b111: alu_op = ALU_AND;
         endcase
       end
-      REG_IMM : begin
-        databus_mux_sel = DATABUS_ALU;
-        rs2_mux_sel = RS2_IMM;
+      REG_REG_WB : begin
         load_reg = 1'b1;
+        databus_mux_sel = DATABUS_ALU;
+      end
+      REG_IMM : begin
+        load_alu_reg = 1'b1;
+        rs2_mux_sel = RS2_IMM;
         /*
         alu_op = {1'b0,funct3};
         if (funct3 == 3'b001 || funct3 == 3'b101) begin
@@ -596,27 +667,52 @@ module control
           end
         endcase
       end
-      LUI_0 : begin
+      REG_IMM_WB : begin
         load_reg = 1'b1;
-        rs2_mux_sel = RS2_IMM;
         databus_mux_sel = DATABUS_ALU;
+      end
+      LUI_0 : begin
+        load_alu_reg = 1'b1;
+        rs2_mux_sel = RS2_IMM;
         alu_op = ALU_PASS_RS2;
       end
-      JALR_0 : begin
+      LUI_1 : begin
         load_reg = 1'b1;
         databus_mux_sel = DATABUS_ALU;
+      end
+      AUIPC_0 : begin
+        load_alu_reg = 1'b1;
+        rs2_mux_sel = RS2_IMM;
+        rs1_mux_sel = RS1_PC;
+      end
+      AUIPC_1 : begin
+        load_reg = 1'b1;
+        databus_mux_sel = DATABUS_ALU;
+      end
+      JALR_0 : begin
+        load_alu_reg = 1'b1;
         rs1_mux_sel = RS1_4;
         rs2_mux_sel = RS2_PC;
       end
+      JALR_0_WB : begin
+        load_reg = 1'b1;
+        databus_mux_sel = DATABUS_ALU;
+      end
       JALR_1 : begin
-        load_pc = 1'b1;
+        load_alu_reg = 1'b1;
         rs2_mux_sel = RS2_IMM;
+      end
+      JALR_1_WB : begin
+        load_pc = 1'b1;
         databus_mux_sel = DATABUS_ALU;
       end
       LD_0 : begin
+        load_alu_reg = 1'b1;
+        rs2_mux_sel = RS2_IMM;
+      end
+      LD_0_WB : begin
         load_mar = 1'b1;
         databus_mux_sel = DATABUS_ALU;
-        rs2_mux_sel = RS2_IMM;
       end
       LD_1 : begin
         mem_read = 1'b1;
@@ -631,15 +727,21 @@ module control
         load_reg = 1'b1;
       end
       ST_0 : begin
-        load_mar = 1'b1;
-        databus_mux_sel = DATABUS_ALU;
+        load_alu_reg = 1'b1;
         rs2_mux_sel = RS2_IMM;
       end
+      ST_0_WB : begin
+        load_mar = 1'b1;
+        databus_mux_sel = DATABUS_ALU;
+      end
       ST_1 : begin
+        load_alu_reg = 1'b1;
+        alu_op = ALU_PASS_RS2;
+      end
+      ST_1_WB : begin
         load_mdr = 1'b1;
         databus_mux_sel = DATABUS_ALU;
         mdr_mux_sel = 1'b1;
-        alu_op = ALU_PASS_RS2;
       end
       ST_2 : begin
         mem_write = 1'b1;

--- a/rtl/control.sv
+++ b/rtl/control.sv
@@ -28,41 +28,57 @@ module control
 (
   input logic clk,
   input logic rst_n,
-  output logic load_mar,
-  output logic load_pc,
-  output logic load_ir,
-  output logic load_mdr,
-  output logic load_reg,
-  output logic load_imm_reg,     // Load immediate register
-  output logic load_alu_reg,     // Load ALU output register
-  output logic mdr_mux_sel,
-  output rs1_mux_sel_t  rs1_mux_sel,
-  output rs2_mux_sel_t  rs2_mux_sel,
-  output alu_op_t alu_op,
-  output databus_mux_sel_t databus_mux_sel,
-  output logic mem_write,
-  output logic mem_read,
-  output mem_size_t mem_size,
-  output logic load_unsigned,
-  output logic [4:0] rs1,
-  output logic [4:0] rs2,
-  output logic [4:0] rd,
-  input logic mem_resp,
-  input logic [2:0] bsr,
-  input logic [31:0] ir,
-  output logic [31:0] immediate,
+
+  // Register load enables
+  output logic load_mar,         // Load Memory Address Register
+  output logic load_pc,          // Load Program Counter
+  output logic load_ir,          // Load Instruction Register
+  output logic load_mdr,         // Load Memory Data Register
+  output logic load_reg,         // Load register file (write enable)
+
+  // Pipeline register loads
+  output logic load_imm_reg,     // Load immediate register (breaks IMM gen critical path)
+  output logic load_alu_reg,     // Load ALU output register (breaks ALU->databus critical path)
+
+  // Multiplexer selects
+  output logic mdr_mux_sel,      // Select source for MDR input
+  output rs1_mux_sel_t  rs1_mux_sel,  // Select source for RS1 input to ALU
+  output rs2_mux_sel_t  rs2_mux_sel,  // Select source for RS2 input to ALU
+  output alu_op_t alu_op,        // Select ALU operation
+  output databus_mux_sel_t databus_mux_sel,  // Select source for shared databus
+
+  // Memory interface
+  output logic mem_write,        // Memory write enable
+  output logic mem_read,         // Memory read enable
+  output mem_size_t mem_size,    // Memory access size (byte/halfword/word)
+  output logic load_unsigned,    // Zero-extend for unsigned loads
+
+  // Register indices
+  output logic [4:0] rs1,        // RS1 register index
+  output logic [4:0] rs2,        // RS2 register index
+  output logic [4:0] rd,         // RD register index
+
+  // Inputs
+  input logic mem_resp,          // Memory response (read/write complete)
+  input logic [2:0] bsr,         // Branch status register (beq, blt, bltu)
+  input logic [31:0] ir,         // Instruction register
+
+  // Immediate output
+  output logic [31:0] immediate, // Sign/zero-extended immediate value
+
   // CSR interface
-  output logic [2:0] funct3_out,  // Instruction funct3 field for CSR operations
+  output logic [2:0] funct3_out, // Instruction funct3 field for CSR operations
   output logic csr_access,       // High when accessing CSR
-  output logic csr_write,         // High when writing to CSR (for instret increment)
-  input logic csr_valid,          // CSR address valid signal
+  output logic csr_write,        // High when writing to CSR (for instret increment)
+  input logic csr_valid,         // CSR address valid signal
+
   // Trap handling interface
-  output logic trap_entry,        // High during trap entry (write mepc, mcause, mtval)
-  output logic load_pc_from_csr,  // High when loading PC from CSR (mtvec or mepc)
-  output logic load_mepc,         // High when writing current PC to mepc
-  output logic load_mcause,       // High when writing mcause
-  output logic load_mtval,        // High when writing mtval
-  output logic [31:0] mcause_val  // Value to write to mcause
+  output logic trap_entry,       // High during trap entry (write mepc, mcause, mtval)
+  output logic load_pc_from_csr, // High when loading PC from CSR (mtvec or mepc)
+  output logic load_mepc,        // High when writing current PC to mepc
+  output logic load_mcause,      // High when writing mcause
+  output logic load_mtval,       // High when writing mtval
+  output logic [31:0] mcause_val // Value to write to mcause
 );
 
   logic [2:0] instr_type;

--- a/rtl/control/imm_gen.sv
+++ b/rtl/control/imm_gen.sv
@@ -1,11 +1,29 @@
 /*
- * Immediate value generator
+ * Immediate Value Generator
  *
- * Outputs all the immediate values based on the instruction register.
- * Definitions for both the 32 bit G instructions and TODO eventually the 16
- * bit compressed C instructions.
+ * This module generates immediate values for RISC-V instructions based on
+ * the instruction format type. It constructs sign-extended or zero-extended
+ * immediates from the instruction fields.
  *
- * 2022 04 10
+ * Supported Instruction Formats:
+ *   - I-type: Sign-extended 12-bit immediate (bits [31:20] and [11:7])
+ *   - S-type: Sign-extended 12-bit immediate (bits [31:25] and [11:7])
+ *   - B-type: Sign-extended 13-bit immediate (bits [31], [7], [30:25], [11:8])
+ *   - U-type: Zero-extended 20-bit immediate (bits [31:12])
+ *   - J-type: Sign-extended 20-bit immediate (bits [31], [19:12], [20], [30:21])
+ *   - R-type: 5-bit shift amount (bits [24:20]) for shift instructions
+ *
+ * Input:
+ *   - ir[31:7]: Instruction bits 31-7 (opcode, funct3, rs1, funct7, rd, shamt, imm)
+ *   - instr_type: Instruction format type (R, I, S, B, U, J)
+ *
+ * Output:
+ *   - imm: 32-bit immediate value (sign or zero extended as appropriate)
+ *
+ * Note:
+ *   - ir[6:0] (opcode) is not included in input to save wiring
+ *   - Sign extension replicates bit [31] to upper bits
+ *   - Zero extension fills upper bits with 0
  */
 
 `include "datatypes.sv"
@@ -16,43 +34,91 @@ module imm_gen_32 (
   output logic [31:0] imm
 );
 
-logic [31:0] imm_i, imm_s, imm_b, imm_u, imm_j;
-assign imm_i = {{20{ir[31]}},ir[31:20]};
-assign imm_s = {{20{ir[31]}},{ir[31:25],ir[11:7]}};
-assign imm_b = {{19{ir[31]}},{ir[31],ir[7],ir[30:25],ir[11:8],1'b0}};
-assign imm_u = {ir[31:12],12'b0};
-assign imm_j = {{12{ir[31]}},{ir[19:12],ir[20],ir[30:21],1'b0}};
+// ============================================================================
+// I-type Immediate (Sign-Extended 12-bit)
+// ============================================================================
+// Format: [31:20] [11:7]
+// Example: ADDI x1, x0, 100 -> imm = 0x64
+logic [31:0] imm_i;
+assign imm_i = {{20{ir[31]}}, ir[31:20]};
+
+// ============================================================================
+// S-type Immediate (Sign-Extended 12-bit)
+// ============================================================================
+// Format: [31:25] [11:7]
+// Example: SW x2, 100(x1) -> imm = 0x64
+logic [31:0] imm_s;
+assign imm_s = {{20{ir[31]}}, {ir[31:25], ir[11:7]}};
+
+// ============================================================================
+// B-type Immediate (Sign-Extended 13-bit)
+// ============================================================================
+// Format: [31] [7] [30:25] [11:8] [6:5]
+// Bits [6:5] are always 0
+// Example: BEQ x1, x2, offset -> imm = sign-extended offset
+logic [31:0] imm_b;
+assign imm_b = {{19{ir[31]}}, {ir[31], ir[7], ir[30:25], ir[11:8], 1'b0}};
+
+// ============================================================================
+// U-type Immediate (Zero-Extended 20-bit)
+// ============================================================================
+// Format: [31:12] [11:0] = 0
+// Example: LUI x1, 0x1234 -> imm = 0x12340000
+logic [31:0] imm_u;
+assign imm_u = {ir[31:12], 12'b0};
+
+// ============================================================================
+// J-type Immediate (Sign-Extended 20-bit)
+// ============================================================================
+// Format: [31] [19:12] [20] [30:21] [19:20]
+// Example: JAL x1, offset -> imm = sign-extended offset
+logic [31:0] imm_j;
+assign imm_j = {{12{ir[31]}}, {ir[19:12], ir[20], ir[30:21], 1'b0}};
+
+// ============================================================================
+// R-type Shift Amount (5-bit)
+// ============================================================================
+// Format: [31:25] [24:20]
+// Example: SLLI x1, x0, 4 -> imm = 0x4
+logic [31:0] imm_r;
+assign imm_r = {27'b0, ir[24:20]};
 
 always_comb begin
   imm = 0;
   case (instr_type)
     INSTR_I: begin
-      // Sign Extended Immediate[11:0]
+      // Sign-extended 12-bit immediate for I-type instructions
+      // Used by: ADDI, SLTI, XORI, SLLI, SRLI, SRAI, LB, LH, LW, etc.
       imm = imm_i;
     end
     INSTR_S: begin
-      // Sign Extended Immediate[11:0]
+      // Sign-extended 12-bit immediate for S-type instructions
+      // Used by: SB, SH, SW
       imm = imm_s;
     end
     INSTR_B: begin
-      // Sign Extended Immediate
+      // Sign-extended 13-bit immediate for B-type instructions
+      // Used by: BEQ, BNE, BLT, BGE, BLTU, BGEU
       imm = imm_b;
     end
     INSTR_U: begin
-      // Unsigned 32b Immedate
+      // Zero-extended 20-bit immediate for U-type instructions
+      // Used by: LUI, AUIPC
       imm = imm_u;
     end
     INSTR_J: begin
-      // Sign Extended Immediate[20:1]
+      // Sign-extended 20-bit immediate for J-type instructions
+      // Used by: JAL
       imm = imm_j;
     end
     INSTR_R: begin
-      // For shift immediate instructions (SLLI, SRLI, SRAI)
-      // Extract shift amount from bits [24:20] (shamt field)
-      imm = {27'b0, ir[24:20]};
+      // 5-bit shift amount for R-type shift instructions
+      // Used by: SLLI, SRLI, SRAI (when funct3 = 001/101/101 and arithmetic=1)
+      imm = imm_r;
     end
     default: begin
-
+      // Default: zero immediate
+      imm = 32'b0;
     end
   endcase
 end

--- a/rtl/core_top.sv
+++ b/rtl/core_top.sv
@@ -67,8 +67,12 @@ wire load_pc;
 wire load_reg;
 wire load_mar;
 wire load_mdr;
+wire load_imm_reg;
+wire load_alu_reg;
 wire mdr_mux_sel;
 wire [31:0] imm;
+logic [31:0] imm_reg;
+logic [31:0] alu_reg;
 
 // Byte lane signals for sub-word memory access
 mem_size_t mem_size;
@@ -104,6 +108,24 @@ program_register #(.WIDTH(32), .INIT('h1000)) u_pc (.clk(clk), .rst_n(rst_n), .i
 program_register #(.WIDTH(32), .INIT(0)) u_mar (.clk(clk), .rst_n(rst_n), .in(databus), .out(mar_out), .load(load_mar));
 program_register #(.WIDTH(32), .INIT(0)) u_mdr (.clk(clk), .rst_n(rst_n), .in(mdr_in), .out(mdr_out), .load(load_mdr));
 
+// Immediate register - pipeline register to break IMM gen critical path
+always_ff @(posedge clk or negedge rst_n) begin
+  if (!rst_n) begin
+    imm_reg <= 32'b0;
+  end else if (load_imm_reg) begin
+    imm_reg <= imm;
+  end
+end
+
+// ALU output register - pipeline register to break ALU->databus critical path
+always_ff @(posedge clk or negedge rst_n) begin
+  if (!rst_n) begin
+    alu_reg <= 32'b0;
+  end else if (load_alu_reg) begin
+    alu_reg <= alu_out;
+  end
+end
+
 // Byte lane module for sub-word memory operations
 byte_lane u_byte_lane (
   // Load path: memory -> register file (with byte extraction and sign extension)
@@ -137,7 +159,7 @@ always_comb begin
     // Read mtvec (TRAP_ENTRY_4) or mepc (MRET_0)
     trap_csr_addr = trap_entry ? 12'h305 : 12'h341;  // mtvec or mepc
   end else begin
-    trap_csr_addr = imm[11:0];
+    trap_csr_addr = imm_reg[11:0];  // CSR address from immediate register
   end
 end
 
@@ -218,6 +240,8 @@ control u_control (
   .load_ir(load_ir),
   .load_mdr(load_mdr),
   .load_reg(load_reg),
+  .load_imm_reg(load_imm_reg),
+  .load_alu_reg(load_alu_reg),
   .mem_write(mem_write),
   .mem_read(mem_read),
   .mem_resp(mem_resp),
@@ -255,7 +279,7 @@ alu #(.WIDTH(32)) u_alu (
 mux8 #(.WIDTH(32)) u_databus_mux (
   .sel(databus_mux_sel),
   .a(pc_out),          // DATABUS_PC = 0
-  .b(alu_out),         // DATABUS_ALU = 1
+  .b(alu_reg),         // DATABUS_ALU = 1 (pipeline register)
   .c(mdr_out),         // DATABUS_MDR = 2
   .d('b0 /* mar_out */), // DATABUS_MAR = 3
   .e(csr_rdata),       // DATABUS_CSR = 4
@@ -282,7 +306,7 @@ mux4 #(.WIDTH(32)) u_rs2_mux (
   .sel(rs2_mux_sel),
   .a(rs2_out),
   .b('b0),
-  .c(imm),
+  .c(imm_reg),       // Use pipeline register for immediate
   .d(pc_out),
   .y(rs2_mux_out));
 

--- a/rtl/datatypes.sv
+++ b/rtl/datatypes.sv
@@ -1,112 +1,157 @@
 /* datatypes.sv
-*/
+ *
+ * Type definitions for the RISC-V 32I processor
+ *
+ * This file defines all the enumerated types used throughout the RTL codebase
+ * for control signals, instruction formats, and operation codes.
+ */
 
 `ifndef __DATATYPES_SV__
 `define __DATATYPES_SV__
 
+// ============================================================================
+// Databus Mux Selection
+// ============================================================================
+// Selects which source drives the shared databus
 typedef enum bit [2:0] {
-  DATABUS_PC=0,
-  DATABUS_ALU,
-  DATABUS_MDR,
-  DATABUS_MAR,
-  DATABUS_CSR
+  DATABUS_PC    = 0,  // Program counter (for JALR, JAL, branch targets)
+  DATABUS_ALU,  // ALU output (for register writes, memory addresses)
+  DATABUS_MDR,  // Memory Data Register (for load results)
+  DATABUS_MAR,  // Memory Address Register (unused in current design)
+  DATABUS_CSR   // CSR read data (for CSR operations, trap handling)
 } databus_mux_sel_t;
 
+// ============================================================================
+// RS1 Mux Selection
+// ============================================================================
+// Selects source for RS1 input to ALU
 typedef enum bit [1:0] {
-  RS1_OUT=0,
-  RS1_PC,
-  RS1_2,
-  RS1_4
+  RS1_OUT  = 0,  // RS1 from register file
+  RS1_PC,  // PC + 4 (for JAL return address, JALR target base)
+  RS1_2,  // Constant value 2 (unused)
+  RS1_4   // Constant value 4 (for PC + 4 increment)
 } rs1_mux_sel_t;
 
+// ============================================================================
+// RS2 Mux Selection
+// ============================================================================
+// Selects source for RS2 input to ALU
 typedef enum bit [1:0] {
-  RS2_OUT=0,
-  RS2_SEL,
-  RS2_IMM,
-  RS2_PC
+  RS2_OUT  = 0,  // RS2 from register file
+  RS2_SEL,  // RS2 from register file (alternate name)
+  RS2_IMM,  // Sign-extended immediate (for I-type instructions)
+  RS2_PC   // PC + 4 (for JAL return address)
 } rs2_mux_sel_t;
 
+// ============================================================================
+// ALU Operations
+// ============================================================================
+// All standard RV32I integer operations
 typedef enum bit [3:0] {
-  ALU_ADD=0,
-  ALU_SLL,
-  ALU_SLT,
-  ALU_SLTU,
-  ALU_XOR,
-  ALU_SRL,
-  ALU_OR,
-  ALU_AND,
-  ALU_SUB,
-  ALU_PASS_RS1,
-  ALU_PASS_RS2,
-  ALU_SRA=13
+  ALU_ADD    = 0,  // Addition
+  ALU_SLL,  // Logical shift left (shift amount in bits [4:0] of B)
+  ALU_SLT,  // Set less than (signed comparison)
+  ALU_SLTU, // Set less than unsigned (unsigned comparison)
+  ALU_XOR,  // Exclusive OR
+  ALU_SRL,  // Logical shift right (shift amount in bits [4:0] of B)
+  ALU_OR,   // Bitwise OR
+  ALU_AND,  // Bitwise AND
+  ALU_SUB,  // Subtraction
+  ALU_PASS_RS1,  // Pass RS1 through (used for LUI, AUIPC)
+  ALU_PASS_RS2,  // Pass RS2 through (used for LUI)
+  ALU_SRA   = 13  // Arithmetic shift right (shift amount in bits [4:0] of B)
 } alu_op_t;
 
+// ============================================================================
+// Branch Condition Encodings
+// ============================================================================
+// Used for branch status register (BSR) output from ALU
 typedef enum bit [2:0] {
-  BEQ=0,
-  BNE,
-  BRANCH_RESERVED_1,
-  BRANCH_RESERVED_2,
-  BLT,
-  BGE,
-  BLTU,
-  BGEU
+  BEQ  = 0,  // Branch if equal (a == b)
+  BNE,  // Branch if not equal (a != b)
+  BRANCH_RESERVED_1,  // Reserved
+  BRANCH_RESERVED_2,  // Reserved
+  BLT,  // Branch if less than (signed)
+  BGE,  // Branch if greater than or equal (signed)
+  BLTU, // Branch if less than unsigned
+  BGEU  // Branch if greater than or equal unsigned
 } branch_t;
 
+// ============================================================================
+// Instruction Format Types
+// ============================================================================
+// RISC-V instruction formats
 typedef enum bit [2:0] {
-  INSTR_R,
-  INSTR_I,
-  INSTR_S,
-  INSTR_B,
-  INSTR_U,
-  INSTR_J,
-  INSTR_ERR
+  INSTR_R   = 0,  // R-type: register-register operations (ALU, etc.)
+  INSTR_I,  // I-type: immediate operations (loads, stores, ALUI, branches)
+  INSTR_S,  // S-type: store operations
+  INSTR_B,  // B-type: branch operations
+  INSTR_U,  // U-type: upper immediate (LUI, AUIPC)
+  INSTR_J,  // J-type: jump operations (JAL)
+  INSTR_ERR // Error/invalid instruction
 } instr_format_t;
 
+// ============================================================================
+// Instruction Opcodes
+// ============================================================================
+// 7-bit opcode fields for instruction classification
 typedef enum bit [6:0] {
-  LUI    = 7'b0110111,
-  AUIPC  = 7'b0010111,
-  JAL    = 7'b1101111,
-  JALR   = 7'b1100111,
-  BRANCH = 7'b1100011,
-  LD     = 7'b0000011,
-  ST     = 7'b0100011,
-  ALUI   = 7'b0010011,
-  ALU    = 7'b0110011,
-  FENCE  = 7'b0001111,
-  ECSR   = 7'b1110011
+  LUI    = 7'b0110111,  // Load upper immediate
+  AUIPC  = 7'b0010111,  // Add upper immediate to PC
+  JAL    = 7'b1101111,  // Jump and link
+  JALR   = 7'b1100111,  // Jump and link register
+  BRANCH = 7'b1100011,  // Branch (BEQ, BNE, BLT, etc.)
+  LD     = 7'b0000011,  // Load (LB, LH, LW, LBU, LHU)
+  ST     = 7'b0100011,  // Store (SB, SH, SW)
+  ALUI   = 7'b0010011,  // ALU immediate (ADDI, ANDI, ORI, XORI, SLLI, SRLI, SRAI)
+  ALU    = 7'b0110011,  // ALU register (ADD, SUB, SLL, etc.)
+  FENCE  = 7'b0001111,  // Fence (FENCE, FENCE.I)
+  ECSR   = 7'b1110011   // CSR access (CSRRW, CSRRS, CSRRC, ECALL, EBREAK, MRET)
 } opcode_t;
 
-// Memory access size for load/store operations
+// ============================================================================
+// Memory Access Size
+// ============================================================================
+// Used for sub-word load/store operations
 typedef enum bit [1:0] {
-  MEM_SIZE_BYTE = 2'b00,
-  MEM_SIZE_HALF = 2'b01,
-  MEM_SIZE_WORD = 2'b10
+  MEM_SIZE_BYTE  = 2'b00,  // Byte access (8 bits)
+  MEM_SIZE_HALF  = 2'b01,  // Halfword access (16 bits)
+  MEM_SIZE_WORD  = 2'b10   // Word access (32 bits)
 } mem_size_t;
 
-// Load funct3 values
+// ============================================================================
+// Load Instruction Funct3 Values
+// ============================================================================
+// Distinguishes between different load operations
 typedef enum bit [2:0] {
-  LD_BYTE  = 3'b000,  // LB - load byte (sign extended)
-  LD_HALF  = 3'b001,  // LH - load halfword (sign extended)
-  LD_WORD  = 3'b010,  // LW - load word
-  LD_BYTEU = 3'b100,  // LBU - load byte unsigned
-  LD_HALFU = 3'b101   // LHU - load halfword unsigned
+  LD_BYTE  = 3'b000,  // LB - Load byte (sign extended)
+  LD_HALF  = 3'b001,  // LH - Load halfword (sign extended)
+  LD_WORD  = 3'b010,  // LW - Load word
+  LD_BYTEU = 3'b100,  // LBU - Load byte unsigned (zero extended)
+  LD_HALFU = 3'b101   // LHU - Load halfword unsigned (zero extended)
 } load_funct3_t;
 
-// Store funct3 values
+// ============================================================================
+// Store Instruction Funct3 Values
+// ============================================================================
+// Distinguishes between different store operations
 typedef enum bit [2:0] {
-  ST_BYTE = 3'b000,   // SB - store byte
-  ST_HALF = 3'b001,   // SH - store halfword
-  ST_WORD = 3'b010    // SW - store word
+  ST_BYTE = 3'b000,   // SB - Store byte
+  ST_HALF = 3'b001,   // SH - Store halfword
+  ST_WORD = 3'b010    // SW - Store word
 } store_funct3_t;
 
-// CSR operation funct3 values
+// ============================================================================
+// CSR Operation Funct3 Values
+// ============================================================================
+// Atomic read-modify-write operations on Control Status Registers
 typedef enum bit [2:0] {
-  CSR_RW  = 3'b001,   // CSRRW  - Atomic Read/Write
-  CSR_RS  = 3'b010,   // CSRRS  - Atomic Read and Set Bits
-  CSR_RC  = 3'b011,   // CSRRC  - Atomic Read and Clear Bits
-  CSR_RWI = 3'b101,   // CSRRWI - Atomic Read/Write Immediate
-  CSR_RSI = 3'b110,   // CSRRSI - Atomic Read and Set Bits Immediate
-  CSR_RCI = 3'b111    // CSRRCI - Atomic Read and Clear Bits Immediate
+  CSR_RW  = 3'b001,   // CSRRW  - Atomic Read/Write (rd = old_csr, csr = rs1)
+  CSR_RS  = 3'b010,   // CSRRS  - Atomic Read and Set Bits (rd = old_csr, csr = old_csr | rs1)
+  CSR_RC  = 3'b011,   // CSRRC  - Atomic Read and Clear Bits (rd = old_csr, csr = old_csr & ~rs1)
+  CSR_RWI = 3'b101,   // CSRRWI - Atomic Read/Write Immediate (rd = old_csr, csr = imm)
+  CSR_RSI = 3'b110,   // CSRRSI - Atomic Read and Set Bits Immediate (rd = old_csr, csr = old_csr | imm)
+  CSR_RCI = 3'b111    // CSRRCI - Atomic Read and Clear Bits Immediate (rd = old_csr, csr = old_csr & ~imm)
 } csr_op_t;
 
 `endif

--- a/rtl/mux4.sv
+++ b/rtl/mux4.sv
@@ -1,12 +1,28 @@
-/* mux.sv
- * Mux definitions.
+/* mux4.sv
+ *
+ * Multiplexer modules for the RISC-V 32I processor
+ *
+ * This file contains multiplexer implementations used throughout the datapath
+ * for routing signals between various components.
+ *
+ * Multiplexers are used to:
+ *   - Select ALU operands (RS1, RS2)
+ *   - Select databus source (PC, ALU, MDR, CSR, etc.)
+ *   - Select MDR source (load data vs. databus)
+ *
+ * All multiplexers are parameterized by WIDTH to support different bit widths.
  */
 
+// ============================================================================
+// 2:1 Multiplexer
+// ============================================================================
+// Selects between two inputs based on a single-bit select signal
+// Used as building block for larger multiplexers
 module mux2 #(parameter WIDTH=32) (
-  input logic [WIDTH-1:0] a,
-  input logic [WIDTH-1:0] b,
-  input logic sel,
-  output logic [WIDTH-1:0] y
+  input logic [WIDTH-1:0] a,  // Input A
+  input logic [WIDTH-1:0] b,  // Input B
+  input logic sel,            // Select signal (0=A, 1=B)
+  output logic [WIDTH-1:0] y  // Output
 );
 
 always_comb begin
@@ -18,17 +34,23 @@ end
 
 endmodule : mux2
 
+// ============================================================================
+// 4:1 Multiplexer
+// ============================================================================
+// Selects between four inputs using a 2-bit select signal
+// Implemented using two cascaded 2:1 multiplexers
 module mux4 #(parameter WIDTH=32) (
-  input logic [WIDTH-1:0] a,
-  input logic [WIDTH-1:0] b,
-  input logic [WIDTH-1:0] c,
-  input logic [WIDTH-1:0] d,
-  input logic [1:0] sel,
-  output logic [WIDTH-1:0] y
+  input logic [WIDTH-1:0] a,  // Input A (sel=00)
+  input logic [WIDTH-1:0] b,  // Input B (sel=01)
+  input logic [WIDTH-1:0] c,  // Input C (sel=10)
+  input logic [WIDTH-1:0] d,  // Input D (sel=11)
+  input logic [1:0] sel,      // Select signal
+  output logic [WIDTH-1:0] y  // Output
 );
 
 logic [WIDTH-1:0] n1, n2;
 
+// First level: select between (a,b) and (c,d)
 mux2 u_mux_0 (
   .a(a),
   .b(b),
@@ -41,6 +63,7 @@ mux2 u_mux_1 (
   .sel(sel[0]),
   .y(n2));
 
+// Second level: select between results of first level
 mux2 u_mux_2 (
   .a(n1),
   .b(n2),
@@ -49,21 +72,27 @@ mux2 u_mux_2 (
 
 endmodule : mux4
 
+// ============================================================================
+// 8:1 Multiplexer
+// ============================================================================
+// Selects between eight inputs using a 3-bit select signal
+// Implemented using cascaded 4:1 and 2:1 multiplexers
 module mux8 #(parameter WIDTH=32) (
-  input logic [WIDTH-1:0] a,
-  input logic [WIDTH-1:0] b,
-  input logic [WIDTH-1:0] c,
-  input logic [WIDTH-1:0] d,
-  input logic [WIDTH-1:0] e,
-  input logic [WIDTH-1:0] f,
-  input logic [WIDTH-1:0] g,
-  input logic [WIDTH-1:0] h,
-  input logic [2:0] sel,
-  output logic [WIDTH-1:0] y
+  input logic [WIDTH-1:0] a,  // Input A (sel=000)
+  input logic [WIDTH-1:0] b,  // Input B (sel=001)
+  input logic [WIDTH-1:0] c,  // Input C (sel=010)
+  input logic [WIDTH-1:0] d,  // Input D (sel=011)
+  input logic [WIDTH-1:0] e,  // Input E (sel=100)
+  input logic [WIDTH-1:0] f,  // Input F (sel=101)
+  input logic [WIDTH-1:0] g,  // Input G (sel=110)
+  input logic [WIDTH-1:0] h,  // Input H (sel=111)
+  input logic [2:0] sel,      // Select signal
+  output logic [WIDTH-1:0] y  // Output
 );
 
 logic [WIDTH-1:0] n1, n2;
 
+// First level: two 4:1 multiplexers
 mux4 u_mux_0 (
   .a(a),
   .b(b),
@@ -80,6 +109,7 @@ mux4 u_mux_1 (
   .sel(sel[1:0]),
   .y(n2));
 
+// Second level: 2:1 multiplexer
 mux2 u_mux_2 (
   .a(n1),
   .b(n2),


### PR DESCRIPTION
This PR adds additional FSM states to register the IMM GEN output and also register the ALU output. Previously there could be a long combinational logic path from IR through immediate logic, alu logic, databus mux reducing timing performance of emulation build.